### PR TITLE
add http post as new util

### DIFF
--- a/hyko_toolkit/utils/__init__.py
+++ b/hyko_toolkit/utils/__init__.py
@@ -43,3 +43,4 @@ from .text_utils.reverse.metadata import func as func  # noqa: F811
 from .text_utils.slice.metadata import func as func  # noqa: F811
 from .text_utils.split.metadata import func as func  # noqa: F811
 from .text_utils.uppercase.metadata import func as func  # noqa: F811
+from .http_utils.post.metadata import func as func  # noqa: F811

--- a/hyko_toolkit/utils/http_utils/post/metadata.py
+++ b/hyko_toolkit/utils/http_utils/post/metadata.py
@@ -1,0 +1,81 @@
+import httpx
+from pydantic import Field
+
+from hyko_sdk.models import CoreModel, Method
+from hyko_toolkit.exceptions import APICallError
+from hyko_toolkit.registry import ToolkitAPI
+
+func = ToolkitAPI(
+    name="post",
+    task="http_utils",
+    description="Send Form Data to to a specified URL",
+)
+
+
+@func.set_param
+class Params(CoreModel):
+    url: str = Field(..., description="A list of URLs to scrape. Protocol must be either 'http' or 'https'.")
+    bearer_token: str = Field(default=None, description="An optional bearer token for authentication.")
+
+
+@func.set_input
+class Inputs(CoreModel):
+    form_input_names: list[str] = Field(
+        ..., description="List of input field names."
+    )
+    form_input_values: list[str] = Field(
+        ..., description="List of corresponding input field values."
+    )
+
+
+@func.set_output
+class Outputs(CoreModel):
+    response_success: bool = Field(default=False, description="Indicates whether the task was successful.")
+
+
+def generate_form_data(input_names: list[str], input_values: list[str]) -> dict[str, str]:
+    """
+    Generates a dictionary of form data by pairing input field names with their corresponding values.
+
+    Args:
+        input_names (list[str]): List of input field names.
+        input_values (list[str]): List of corresponding input field values.
+
+    Returns:
+        dict[str, str]: A dictionary where keys are input field names and values are input field values.
+    """
+    form_data = dict(zip(
+        input_names,
+        input_values
+    ))
+    return form_data
+
+
+@func.on_call
+async def call(inputs: Inputs, params: Params) -> Outputs:
+    async with httpx.AsyncClient() as client:
+        generated_form_data = generate_form_data(
+            inputs.form_input_names,
+            inputs.form_input_values
+        )
+
+        _headers ={
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        if params.bearer_token:
+            _headers["Authorization"] = f"Bearer {params.bearer_token}"
+
+
+        response = await client.request(
+            method=Method.post,
+            url=params.url,
+            headers=_headers,
+            data=generated_form_data,
+            timeout=60 * 10,
+        )
+
+        if not response.is_success:
+            raise APICallError(status=response.status_code, detail=response.text)
+
+        return Outputs(response_success = True)


### PR DESCRIPTION
#61 
1. **Utils Name**: `http_utils`
2. **Function Name**: `post`

3. **Purpose**: The `post` function is responsible for making an HTTP request to a specified URL using the `httpx` library. It sends form data (input values) to the server and handles the response.
4. **Function Signature**:
    - Parameters:
        - `inputs`: An instance of the `Inputs` class, containing input field names and corresponding values.
        - `params`: An instance of the `Params` class, containing the URL and an optional bearer token.
    - Return Type: An instance of the `Outputs` class, indicating whether the task was successful.
5. **Steps Performed**:
    - Creates an asynchronous HTTP client using `httpx.AsyncClient()`.
    - Generates form data by zipping input field names and values together.
    - Sets appropriate headers (including optional bearer token) for the HTTP request.
    - Makes a POST request to the specified URL with the generated form data.
    - Checks if the response is successful.
    - If successful, returns an instance of `Outputs` with `response_success` set to `True`.
    - If not successful, raises an `APICallError` with the response status code and details.